### PR TITLE
Do not throw exception when the Android Gradle Plugin version cannot be identified.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -101,6 +101,6 @@ publishing {
     }
 }
 
-/*signing {
+signing {
     sign(publishing.publications["mavenJava"])
-}*/
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "io.github.goldfish07.reschiper"
-version = "0.1.0-rc6"
+version = "0.1.0-rc7-dev"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_17
@@ -101,6 +101,6 @@ publishing {
     }
 }
 
-signing {
+/*signing {
     sign(publishing.publications["mavenJava"])
-}
+}*/

--- a/src/main/java/io/github/goldfish07/reschiper/plugin/internal/AGP.java
+++ b/src/main/java/io/github/goldfish07/reschiper/plugin/internal/AGP.java
@@ -8,7 +8,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class AGP {
     public static @NotNull String getAGPVersion(@NotNull Project project) {
-        String agpVersion = null;
+        String agpVersion = "Failed to get AGP version";
         for (org.gradle.api.artifacts.ResolvedArtifact artifact : project.getRootProject().getBuildscript().getConfigurations().getByName(ScriptHandler.CLASSPATH_CONFIGURATION)
                 .getResolvedConfiguration().getResolvedArtifacts()) {
             DefaultModuleComponentIdentifier identifier = (DefaultModuleComponentIdentifier) artifact.getId().getComponentIdentifier();
@@ -16,8 +16,6 @@ public class AGP {
                 if ("gradle".equals(identifier.getModule()))
                     agpVersion = identifier.getVersion();
         }
-        if (agpVersion == null)
-            throw new GradleException("Failed to get AGP version");
         return agpVersion;
     }
 }

--- a/src/main/java/io/github/goldfish07/reschiper/plugin/internal/AGP.java
+++ b/src/main/java/io/github/goldfish07/reschiper/plugin/internal/AGP.java
@@ -8,7 +8,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class AGP {
     public static @NotNull String getAGPVersion(@NotNull Project project) {
-        String agpVersion = "Failed to get AGP version";
+        String agpVersion = "Unknown";
         for (org.gradle.api.artifacts.ResolvedArtifact artifact : project.getRootProject().getBuildscript().getConfigurations().getByName(ScriptHandler.CLASSPATH_CONFIGURATION)
                 .getResolvedConfiguration().getResolvedArtifacts()) {
             DefaultModuleComponentIdentifier identifier = (DefaultModuleComponentIdentifier) artifact.getId().getComponentIdentifier();


### PR DESCRIPTION
The method that ResChiper uses to detect the Android Gradle Plugin version does not work properly when using the `plugins` block instead of `buildscript`. Despite this, the plugin is still able to obfuscate AABs properly. This pull request removes the thrown exception and instead will just list that the Android Gradle Plugin version could not be detected. Here is an example of what the output looks like:

```----------------------------------------
 ResChiper Plugin Configuration:
----------------------------------------
- ResChiper version:	0.1.0-rc6
- BundleTool version:	1.17.2
- AGP version:		8.8.0
- Gradle Wrapper:	8.8
----------------------------------------
 App Build Information:
----------------------------------------
- Project name:			ResChiperTestProject
- AGP version:			Failed to get AGP version
- Running Gradle version:	8.11.1
----------------------------------------
```

Although this is not a proper fix for showing the plugin version, it is a suitable workaround to get the plugin working until a more proper fix is made.