### PR TITLE
Add Support for Generating a Universal APK from the AAB

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ resChiper {
     ]
     unusedStringFile = "path/to/your/unused_strings.txt" // strings will be filtered in this file
     localeWhiteList = ["en", "in", "fr"] //keep en,en-xx,in,in-xx,fr,fr-xx and remove others locale.
+    buildUniversalApk = false // Build a universal APK from the obfuscated bundle
+    universalApkName = "universal.apk" // The name for the built universal APK, must end with '.apk'
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -101,6 +101,6 @@ publishing {
     }
 }
 
-/*signing {
+signing {
     sign(publishing.publications["mavenJava"])
-}*/
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,8 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter")
 
     implementation(gradleApi())
+    compileOnly("com.android.tools:common:31.9.0")
+    compileOnly("com.android.tools:sdklib:31.9.0")
     implementation("org.jetbrains:annotations:24.1.0")
     implementation("com.android.tools.build:gradle:8.8.0")
     implementation("com.android.tools.build:bundletool:1.17.2")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "io.github.goldfish07.reschiper"
-version = "0.1.0-rc6"
+version = "0.1.0-rc7-dev"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_17
@@ -101,6 +101,6 @@ publishing {
     }
 }
 
-signing {
+/*signing {
     sign(publishing.publications["mavenJava"])
-}
+}*/

--- a/src/main/java/io/github/goldfish07/reschiper/plugin/Extension.java
+++ b/src/main/java/io/github/goldfish07/reschiper/plugin/Extension.java
@@ -19,6 +19,8 @@ public class Extension {
     private Set<String> fileFilterList = new HashSet<>();
     private Set<String> whiteList = new HashSet<>();
     private Set<String> localeWhiteList = new HashSet<>();
+    private boolean buildUniversalApk = false;
+    private String universalApkName = "universal.apk";
 
     /**
      * Gets whether obfuscation is enabled.
@@ -138,12 +140,30 @@ public class Extension {
     }
 
     /**
+     * Gets the name of the universal APK file.
+     *
+     * @return The name of the universal APK file.
+     */
+    public String getUniversalApkName() {
+        return universalApkName;
+    }
+
+    /**
      * Sets the name of the obfuscated bundle file.
      *
      * @param obfuscatedBundleName The name of the obfuscated bundle file.
      */
     public void setObfuscatedBundleName(String obfuscatedBundleName) {
         this.obfuscatedBundleName = obfuscatedBundleName;
+    }
+
+    /**
+     * Sets the name of the universal APK file.
+     *
+     * @param universalApkName The name of the universal APK file.
+     */
+    public void setUniversalApkName(String universalApkName) {
+        this.universalApkName = universalApkName;
     }
 
     /**
@@ -216,6 +236,24 @@ public class Extension {
      */
     public void setWhiteList(Set<String> whiteList) {
         this.whiteList = whiteList;
+    }
+
+    /**
+     * Sets whether the universal APK should be built.
+     *
+     * @param buildUniversalApk {@code true} to enable building a universal APK; {@code false} to disable it.
+     */
+    public void setBuildUniversalApk(boolean buildUniversalApk) {
+        this.buildUniversalApk = buildUniversalApk;
+    }
+
+    /**
+     * Gets whether the universal APK should be build.
+     *
+     * @return {@code true} if a universal APK should be built; otherwise, {@code false}.
+     */
+    public boolean getBuildUniversalApk() {
+        return buildUniversalApk;
     }
 
     /**

--- a/src/main/java/io/github/goldfish07/reschiper/plugin/command/Command.java
+++ b/src/main/java/io/github/goldfish07/reschiper/plugin/command/Command.java
@@ -1,7 +1,12 @@
 package io.github.goldfish07.reschiper.plugin.command;
 
+import com.android.sdklib.BuildToolInfo;
+import com.android.tools.build.bundletool.androidtools.Aapt2Command;
+import com.android.tools.build.bundletool.commands.BuildApksCommand;
 import com.android.tools.build.bundletool.flags.Flag;
 import com.android.tools.build.bundletool.model.AppBundle;
+import com.android.tools.build.bundletool.model.Password;
+import com.android.tools.build.bundletool.model.SigningConfiguration;
 import com.android.tools.build.bundletool.model.exceptions.CommandExecutionException;
 import com.google.auto.value.AutoValue;
 import io.github.goldfish07.reschiper.plugin.android.JarSigner;
@@ -11,6 +16,7 @@ import io.github.goldfish07.reschiper.plugin.bundle.AppBundleSigner;
 import io.github.goldfish07.reschiper.plugin.command.extensions.BundleFileFilter;
 import io.github.goldfish07.reschiper.plugin.command.extensions.BundleStringFilter;
 import io.github.goldfish07.reschiper.plugin.command.extensions.DuplicateResourceMerger;
+import io.github.goldfish07.reschiper.plugin.command.extensions.UniversalApkPackager;
 import io.github.goldfish07.reschiper.plugin.command.model.DuplicateResMergerCommand;
 import io.github.goldfish07.reschiper.plugin.command.model.FileFilterCommand;
 import io.github.goldfish07.reschiper.plugin.command.model.ObfuscateBundleCommand;
@@ -24,11 +30,16 @@ import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Logger;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 
 import static com.android.tools.build.bundletool.model.utils.files.FilePreconditions.checkFileDoesNotExist;
 import static com.android.tools.build.bundletool.model.utils.files.FilePreconditions.checkFileExistsAndReadable;
@@ -173,6 +184,15 @@ public abstract class Command {
                 signer.execute();
             }
 
+            // package universal apk
+            if (getBuildUniversalApk().isPresent() && getBuildUniversalApk().get() && getStoreFile().isPresent()
+                    && getKeyAlias().isPresent() && getStorePassword().isPresent() && getKeyPassword().isPresent()) {
+                UniversalApkPackager apkPackager = new UniversalApkPackager(
+                        getUniversalApkPath(), getBuildToolInfo(), getOutputPath(), getStoreFile().get(),
+                        getKeyAlias().get(), getStorePassword().get(), getKeyPassword().get());
+                apkPackager.packageApk();
+            }
+
             out = """
                     ----------------------------------------
                      Bundle Summary:
@@ -272,6 +292,13 @@ public abstract class Command {
     public abstract Path getBundlePath();
 
     /**
+     * Gets the path of the universal APK to be processed.
+     *
+     * @return The path of the universal APK.
+     */
+    public abstract Path getUniversalApkPath();
+
+    /**
      * Gets the path where the output bundle file should be created.
      *
      * @return The path for the output bundle file.
@@ -335,6 +362,20 @@ public abstract class Command {
     public abstract DuplicateResMergerCommand getDuplicateResMergeBuilder();
 
     /**
+     * Gets the builder for building the universal APK configuration.
+     *
+     * @return The builder for building the universal APK configuration.
+     */
+    public abstract Optional<Boolean> getBuildUniversalApk();
+
+    /**
+     * Gets the build tool info used for building the universal APK.
+     *
+     * @return The build tool info used for building the universal APK.
+     */
+    public abstract BuildToolInfo getBuildToolInfo();
+
+    /**
      * A builder class for constructing {@link Command} objects with various configuration options.
      * The builder allows setting properties related to processing Android App Bundles, including
      * filtering files, filtering strings, obfuscating resources, and merging duplicated resources.
@@ -351,6 +392,14 @@ public abstract class Command {
          * @return This builder for method chaining.
          */
         public abstract Builder setBundlePath(Path bundlePath);
+
+        /**
+         * Sets the path of the universal APK to be processed.
+         *
+         * @param universalApkPath The path of the universal APK.
+         * @return This builder for method chaining.
+         */
+        public abstract Builder setUniversalApkPath(Path universalApkPath);
 
         /**
          * Sets the path where the output bundle file should be created.
@@ -423,6 +472,22 @@ public abstract class Command {
          * @return This builder for method chaining.
          */
         public abstract Builder setDuplicateResMergeBuilder(DuplicateResMergerCommand mergerCommand);
+
+        /**
+         * Set the flag indicating whether building the universal APK is enabled.
+         *
+         * @param buildUniversalApk A boolean flag indicating whether building the universal APK is enabled.
+         * @return This builder instance for method chaining.
+         */
+        public abstract Builder setBuildUniversalApk(Boolean buildUniversalApk);
+
+        /**
+         * Sets the build tool info used for building the universal APK.
+         *
+         * @param aapt2Path The build tool info used for building the universal APK.
+         * @return This builder instance for method chaining.
+         */
+        public abstract Builder setBuildToolInfo(BuildToolInfo aapt2Path);
 
         /**
          * Builds and returns a {@link Command} object with the specified properties.

--- a/src/main/java/io/github/goldfish07/reschiper/plugin/command/extensions/UniversalApkPackager.java
+++ b/src/main/java/io/github/goldfish07/reschiper/plugin/command/extensions/UniversalApkPackager.java
@@ -1,0 +1,113 @@
+package io.github.goldfish07.reschiper.plugin.command.extensions;
+
+import com.android.sdklib.BuildToolInfo;
+import com.android.tools.build.bundletool.androidtools.Aapt2Command;
+import com.android.tools.build.bundletool.commands.BuildApksCommand;
+import com.android.tools.build.bundletool.model.Password;
+import com.android.tools.build.bundletool.model.SigningConfiguration;
+import io.github.goldfish07.reschiper.plugin.utils.TimeClock;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+/**
+ * The `UniversalApkPackager` class is responsible for building a universal APK based off of the obfuscated
+ * AAB (Android App Bundle).
+ */
+public class UniversalApkPackager {
+    private final Path universalApkPath;
+    private final BuildToolInfo buildToolInfo;
+    private final Path bundlePath;
+    private final Path keystoreFile;
+    private final String keyAlias;
+    private final String storePassword;
+    private final String keyPassword;
+
+    /**
+     * Constructs a `UniversalApkPackager` instance with the provided parameters.
+     *
+     * @param universalApkPath A Path object representing where the universal APK is to be stored.
+     * @param buildToolInfo A BuildToolInfo object used for providing build environment info to Bundletool.
+     * @param bundlePath A Path object representing where the AAB is stored.
+     * @param keystoreFile A Path object representing where the keystore file is located.
+     * @param keyAlias The key alias.
+     * @param storePassword The keystore password.
+     * @param keyPassword The key password.
+     */
+    public UniversalApkPackager(Path universalApkPath, BuildToolInfo buildToolInfo, Path bundlePath, Path keystoreFile,
+                                String keyAlias, String storePassword, String keyPassword) {
+        this.universalApkPath = universalApkPath;
+        this.buildToolInfo = buildToolInfo;
+        this.bundlePath = bundlePath;
+        this.keystoreFile = keystoreFile;
+        this.keyAlias = keyAlias;
+        this.storePassword = "pass:" + storePassword;
+        this.keyPassword = "pass:" + keyPassword;
+    }
+
+    /**
+     * Executes the packaging of the universal APK using the parameters provided at `UniversalApkPackager` object
+     * creation time.
+     */
+    public void packageApk() throws Exception {
+        System.out.println(
+                """
+                ----------------------------------------
+                 Packaging Universal APK:
+                ----------------------------------------
+                - Building APK Set Archive (APKS) file...""");
+
+        final TimeClock timeClock = new TimeClock();
+        final Path apksPath = new File(universalApkPath.toString() + "s").toPath();
+        final Path aapt2Path = new File(buildToolInfo.getPath(BuildToolInfo.PathId.AAPT2)).toPath();
+
+        // Builds the APKS file
+        BuildApksCommand.Builder command = BuildApksCommand.builder()
+                .setBundlePath(bundlePath)
+                .setOutputFile(apksPath)
+                .setAapt2Command(Aapt2Command.createFromExecutablePath(aapt2Path))
+                .setApkBuildMode(BuildApksCommand.ApkBuildMode.UNIVERSAL)
+                .setOutputFormat(BuildApksCommand.OutputFormat.APK_SET);
+
+        if (keystoreFile.toFile().exists()) {
+            command.setSigningConfiguration(SigningConfiguration.extractFromKeystore(
+                    keystoreFile,
+                    keyAlias,
+                    Optional.of(Password.createFromStringValue(storePassword)),
+                    Optional.of(Password.createFromStringValue(keyPassword))
+            ));
+        }
+
+        command.build().execute();
+
+        /*
+            The APKS file is a zip file. Since a universal APK was built, this file will contain a single APK called
+            "universal.apk" that we should extract.
+         */
+        System.out.println("- Extracting universal APK from APKS...");
+        InputStream inputStream;
+        try (ZipFile zipFile = new ZipFile(apksPath.toFile())) {
+            ZipEntry zipEntry = zipFile.getEntry("universal.apk");
+            inputStream = zipFile.getInputStream(zipEntry);
+
+            try (FileOutputStream fileOutputStream = new FileOutputStream(universalApkPath.toFile())) {
+                byte[] buffer = new byte[1024];
+                int bytesRead;
+                while ((bytesRead = inputStream.read(buffer)) != -1) {
+                    fileOutputStream.write(buffer, 0, bytesRead);
+                }
+            }
+            inputStream.close();
+            zipFile.close();
+
+            Files.deleteIfExists(apksPath);
+        }
+        System.out.printf("- Universal APK packaged in %s%n\n", timeClock.getElapsedTime());
+    }
+}

--- a/src/main/java/io/github/goldfish07/reschiper/plugin/internal/AGP.java
+++ b/src/main/java/io/github/goldfish07/reschiper/plugin/internal/AGP.java
@@ -8,7 +8,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class AGP {
     public static @NotNull String getAGPVersion(@NotNull Project project) {
-        String agpVersion = null;
+        String agpVersion = "Failed to get AGP version";
         for (org.gradle.api.artifacts.ResolvedArtifact artifact : project.getRootProject().getBuildscript().getConfigurations().getByName(ScriptHandler.CLASSPATH_CONFIGURATION)
                 .getResolvedConfiguration().getResolvedArtifacts()) {
             DefaultModuleComponentIdentifier identifier = (DefaultModuleComponentIdentifier) artifact.getId().getComponentIdentifier();
@@ -16,8 +16,6 @@ public class AGP {
                 if ("gradle".equals(identifier.getModule()))
                     agpVersion = identifier.getVersion();
         }
-        if (agpVersion == null)
-            throw new GradleException("Failed to get AGP version");
         return agpVersion;
     }
 }

--- a/src/main/java/io/github/goldfish07/reschiper/plugin/internal/BuildToolInfo.java
+++ b/src/main/java/io/github/goldfish07/reschiper/plugin/internal/BuildToolInfo.java
@@ -1,0 +1,26 @@
+package io.github.goldfish07.reschiper.plugin.internal;
+
+import com.android.SdkConstants;
+import com.android.build.api.variant.AndroidComponentsExtension;
+import com.android.repository.Revision;
+import org.gradle.api.Project;
+import org.jetbrains.annotations.NotNull;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class BuildToolInfo {
+    public static @NotNull com.android.sdklib.BuildToolInfo getBuildToolInfo(Project project) {
+        Path buildToolsDir = Paths.get(
+                project.getExtensions().getByType(AndroidComponentsExtension.class).getSdkComponents()
+                        .getSdkDirectory().get().toString(),
+                SdkConstants.FD_BUILD_TOOLS,
+                SdkConstants.CURRENT_BUILD_TOOLS_VERSION
+        );
+
+        return com.android.sdklib.BuildToolInfo.fromStandardDirectoryLayout(
+                Revision.parseRevision(SdkConstants.CURRENT_BUILD_TOOLS_VERSION),
+                buildToolsDir
+        );
+    }
+}

--- a/src/main/java/io/github/goldfish07/reschiper/plugin/tasks/ResChiperTask.java
+++ b/src/main/java/io/github/goldfish07/reschiper/plugin/tasks/ResChiperTask.java
@@ -7,6 +7,7 @@ import io.github.goldfish07.reschiper.plugin.command.model.FileFilterCommand;
 import io.github.goldfish07.reschiper.plugin.command.model.ObfuscateBundleCommand;
 import io.github.goldfish07.reschiper.plugin.command.model.StringFilterCommand;
 import io.github.goldfish07.reschiper.plugin.Extension;
+import io.github.goldfish07.reschiper.plugin.internal.BuildToolInfo;
 import io.github.goldfish07.reschiper.plugin.model.KeyStore;
 import io.github.goldfish07.reschiper.plugin.internal.Bundle;
 import io.github.goldfish07.reschiper.plugin.internal.SigningConfig;
@@ -30,6 +31,8 @@ public class ResChiperTask extends DefaultTask {
     private KeyStore keyStore;
     private Path bundlePath;
     private Path obfuscatedBundlePath;
+    private Path universalApkPath;
+    private com.android.sdklib.BuildToolInfo buildToolInfo;
 
     /**
      * Constructor for the ResChiperTask.
@@ -49,6 +52,8 @@ public class ResChiperTask extends DefaultTask {
         this.variant = variant;
         bundlePath = Bundle.getBundleFilePath(getProject(), variant);
         obfuscatedBundlePath = new File(bundlePath.toFile().getParentFile(), resChiperExtension.getObfuscatedBundleName()).toPath();
+        universalApkPath = new File(bundlePath.toFile().getParentFile(), resChiperExtension.getUniversalApkName()).toPath();
+        buildToolInfo = BuildToolInfo.getBuildToolInfo(getProject());
     }
 
     /**
@@ -66,6 +71,9 @@ public class ResChiperTask extends DefaultTask {
         Command.Builder builder = Command.builder();
         builder.setBundlePath(bundlePath);
         builder.setOutputPath(obfuscatedBundlePath);
+        builder.setUniversalApkPath(universalApkPath);
+        builder.setBuildUniversalApk(resChiperExtension.getBuildUniversalApk());
+        builder.setBuildToolInfo(buildToolInfo);
 
         ObfuscateBundleCommand.Builder obfuscateBuilder = ObfuscateBundleCommand.builder()
                 .setEnableObfuscate(resChiperExtension.getEnableObfuscation())


### PR DESCRIPTION
This pull request adds support for generating a universal APK based off the AAB. I have set the feature to be disabled by default.

While working on this, I referenced the source of the following Gradle plugin: https://github.com/accrescent/bundletool-gradle-plugin