### PR TITLE
Add seed for resources obfuscation

### DIFF
--- a/local.properties
+++ b/local.properties
@@ -1,0 +1,8 @@
+## This file must *NOT* be checked into Version Control Systems,
+# as it contains information specific to your local configuration.
+#
+# Location of the SDK. This is only used by Gradle.
+# For customization when using a Version Control System, please read the
+# header note.
+#Thu Dec 04 15:14:40 MSK 2025
+sdk.dir=/Users/V.Borodkin/Library/Android/sdk

--- a/src/main/java/io/github/goldfish07/reschiper/plugin/Extension.java
+++ b/src/main/java/io/github/goldfish07/reschiper/plugin/Extension.java
@@ -16,6 +16,7 @@ public class Extension {
     private Path mappingFile = null;
     private String obfuscatedBundleName;
     private String unusedStringFile = "";
+    private String obfuscationSeed = null;
     private Set<String> fileFilterList = new HashSet<>();
     private Set<String> whiteList = new HashSet<>();
     private Set<String> localeWhiteList = new HashSet<>();
@@ -216,6 +217,24 @@ public class Extension {
      */
     public void setWhiteList(Set<String> whiteList) {
         this.whiteList = whiteList;
+    }
+
+    /**
+     * Gets the obfuscation seed string used for obfuscation.
+     *
+     * @return The obfuscation seed string, or {@code null} if not set.
+     */
+    public String getObfuscationSeed() {
+        return obfuscationSeed;
+    }
+
+    /**
+     * Sets the obfuscation seed string used for obfuscation.
+     *
+     * @param obfuscationSeed The obfuscation seed string to set, or {@code null} to disable seed-based obfuscation.
+     */
+    public void setObfuscationSeed(String obfuscationSeed) {
+        this.obfuscationSeed = obfuscationSeed;
     }
 
     /**

--- a/src/main/java/io/github/goldfish07/reschiper/plugin/command/Command.java
+++ b/src/main/java/io/github/goldfish07/reschiper/plugin/command/Command.java
@@ -155,7 +155,8 @@ public abstract class Command {
                 Path mappingPath = null;
                 if (bundleCommand.getMappingPath().isPresent())
                     mappingPath = bundleCommand.getMappingPath().get();
-                ResourcesObfuscator obfuscator = new ResourcesObfuscator(getBundlePath(), appBundle, bundleCommand.getWhiteList(), getOutputPath().getParent(), mappingPath);
+                String obfuscationSeed = bundleCommand.getObfuscationSeed().orElse(null);
+                ResourcesObfuscator obfuscator = new ResourcesObfuscator(getBundlePath(), appBundle, bundleCommand.getWhiteList(), getOutputPath().getParent(), mappingPath, obfuscationSeed);
                 obfuscator.withMode(obfuscator.getMode(bundleCommand.getObfuscationMode() == null ? "default" : bundleCommand.getObfuscationMode()));
                 appBundle = obfuscator.obfuscate();
             }

--- a/src/main/java/io/github/goldfish07/reschiper/plugin/command/model/ObfuscateBundleCommand.java
+++ b/src/main/java/io/github/goldfish07/reschiper/plugin/command/model/ObfuscateBundleCommand.java
@@ -103,6 +103,13 @@ public abstract class ObfuscateBundleCommand {
     public abstract Optional<Set<String>> getLanguageWhiteList();
 
     /**
+     * Get an optional obfuscation seed string for obfuscation.
+     *
+     * @return An optional obfuscation seed string.
+     */
+    public abstract Optional<String> getObfuscationSeed();
+
+    /**
      * Builder pattern for constructing {@link ObfuscateBundleCommand} instances.
      */
     @AutoValue.Builder
@@ -195,6 +202,14 @@ public abstract class ObfuscateBundleCommand {
          * @return This builder instance for method chaining.
          */
         public abstract Builder setDisableSign(Boolean disableSign);
+
+        /**
+         * Set the obfuscation seed string for obfuscation.
+         *
+         * @param obfuscationSeed The obfuscation seed string to set.
+         * @return This builder instance for method chaining.
+         */
+        public abstract Builder setObfuscationSeed(String obfuscationSeed);
 
         /**
          * Build a new {@link ObfuscateBundleCommand} instance with the configured properties.

--- a/src/main/java/io/github/goldfish07/reschiper/plugin/obfuscation/ResourcesObfuscator.java
+++ b/src/main/java/io/github/goldfish07/reschiper/plugin/obfuscation/ResourcesObfuscator.java
@@ -40,6 +40,7 @@ public class ResourcesObfuscator {
     private final Path outputMappingPath;
     private final ZipFile bundleZipFile;
     private final ResourceMapping resourceMapping;
+    private final String obfuscationSeed;
 
     public enum MODE {
         DIR,
@@ -63,9 +64,10 @@ public class ResourcesObfuscator {
      * @param whiteListRules       The set of whitelisting rules for resources.
      * @param outputLogLocationDir The directory where log files will be generated.
      * @param mappingPath          The path to the resource mapping file (can be null).
+     * @param obfuscationSeed      The obfuscation seed string for obfuscation (can be null).
      * @throws IOException If an I/O error occurs during initialization.
      */
-    public ResourcesObfuscator(Path bundlePath, AppBundle rawAppBundle, Set<String> whiteListRules, Path outputLogLocationDir, Path mappingPath) throws IOException {
+    public ResourcesObfuscator(Path bundlePath, AppBundle rawAppBundle, Set<String> whiteListRules, Path outputLogLocationDir, Path mappingPath, String obfuscationSeed) throws IOException {
         if (mappingPath != null && mappingPath.toFile().exists())
             resourceMapping = new ResourcesMappingParser(mappingPath).parse();
         else
@@ -81,6 +83,7 @@ public class ResourcesObfuscator {
 
         this.rawAppBundle = rawAppBundle;
         this.whiteListRules = whiteListRules;
+        this.obfuscationSeed = obfuscationSeed;
     }
 
     MODE mode;
@@ -177,7 +180,7 @@ public class ResourcesObfuscator {
                 .filter(path -> !resourceMapping.getDirMapping().containsKey(path.toString()))
                 .forEach(path -> {
                     stringObfuscator.reset(null);
-                    String name = stringObfuscator.getReplaceString(resourceMapping.getPathMappingNameList());
+                    String name = stringObfuscator.getReplaceString(resourceMapping.getPathMappingNameList(), obfuscationSeed);
                     if (mode == MODE.FILES || isDirectoryInWhiteList(path.toString())) {
                         if (isDirectoryInWhiteList(path.toString()))
                             System.out.println(" - [whitelist][dir] " + path);
@@ -206,7 +209,7 @@ public class ResourcesObfuscator {
                 if (isResourceInWhiteList(resourceName))
                     System.out.printf(" - [whitelist][resource] %s, id: %s%n", resourceName, resourceId);
                 else {
-                    String name = stringObfuscator.getReplaceString(obfuscationList);
+                    String name = stringObfuscator.getReplaceString(obfuscationList, obfuscationSeed);
                     obfuscationList.add(name);
                     String obfuscatedResourceName = AppBundleUtils.getResourceFullName(entry.getPackage().getPackageName(), entry.getType().getName(), name);
                     resourceMapping.putResourceMapping(resourceName, obfuscatedResourceName);
@@ -254,7 +257,7 @@ public class ResourcesObfuscator {
                             } else {
                                 if ((mode == MODE.FILES || mode == MODE.DEFAULT)) {
                                     fileSuffix = FileOperation.getFileSuffix(entry.getPath());
-                                    obfuscatedName = guardStringBuilder.getReplaceString(mapping);
+                                    obfuscatedName = guardStringBuilder.getReplaceString(mapping, obfuscationSeed);
                                 } else {
                                     fileSuffix = "";
                                     obfuscatedName = FileOperation.getFileSimpleName(entry.getPath());

--- a/src/main/java/io/github/goldfish07/reschiper/plugin/obfuscation/StringObfuscator.java
+++ b/src/main/java/io/github/goldfish07/reschiper/plugin/obfuscation/StringObfuscator.java
@@ -114,15 +114,58 @@ public class StringObfuscator {
     }
 
     /**
+     * Generates a hash-based string that starts with a letter.
+     *
+     * @param input The input string to hash.
+     * @return A hash string that starts with a letter.
+     */
+    private String getHashStartingWithLetter(String input) {
+        int hash = input.hashCode();
+        String hashStr = Integer.toHexString(Math.abs(hash));
+
+        // Ensure the hash starts with a letter
+        if (Character.isDigit(hashStr.charAt(0))) {
+            // Map digits to letters: 0->a, 1->b, 2->c, 3->d, 4->e, 5->f, 6->g, 7->h, 8->i, 9->j
+            char firstChar = (char) ('a' + (hashStr.charAt(0) - '0'));
+            hashStr = firstChar + hashStr.substring(1);
+        }
+
+        return hashStr;
+    }
+
+    /**
      * Gets a replacement string from the buffer based on the provided names.
      *
      * @param names A collection of names to exclude from the replacements.
+     * @param obfuscationSeed An optional obfuscation seed string for obfuscation. If provided, uses seed-based hashing logic.
      * @return The replacement string.
      * @throws IllegalArgumentException If the replacement buffer is empty.
      */
-    public String getReplaceString(Collection<String> names) throws IllegalArgumentException {
+    public String getReplaceString(Collection<String> names, String obfuscationSeed) throws IllegalArgumentException {
         if (replaceStringBuffer.isEmpty())
             throw new IllegalArgumentException("Now can only obfuscate up to " + MAX_OBFUSCATION_LIMIT + " in a single type");
+
+        // If obfuscationSeed is provided, use seed-based hashing logic
+        if (obfuscationSeed != null && !obfuscationSeed.isEmpty()) {
+            String result;
+            if (names != null) {
+                for (int i = 0; i < replaceStringBuffer.size(); i++) {
+                    result = replaceStringBuffer.get(i);
+                    String nameWithHash = getHashStartingWithLetter(result + obfuscationSeed);
+
+                    if (names.contains(nameWithHash)) {
+                        continue;
+                    }
+
+                    replaceStringBuffer.remove(i);
+                    return nameWithHash;
+                }
+            }
+            result = replaceStringBuffer.remove(0);
+            return getHashStartingWithLetter(result + obfuscationSeed);
+        }
+
+        // Original logic when obfuscationSeed is not provided
         if (names != null)
             for (int i = 0; i < replaceStringBuffer.size(); i++) {
                 String name = replaceStringBuffer.get(i);

--- a/src/main/java/io/github/goldfish07/reschiper/plugin/tasks/ResChiperTask.java
+++ b/src/main/java/io/github/goldfish07/reschiper/plugin/tasks/ResChiperTask.java
@@ -79,6 +79,8 @@ public class ResChiperTask extends DefaultTask {
                 .setLanguageWhiteList(resChiperExtension.getLocaleWhiteList());
         if (resChiperExtension.getMappingFile() != null)
             obfuscateBuilder.setMappingPath(resChiperExtension.getMappingFile());
+        if (resChiperExtension.getObfuscationSeed() != null)
+            obfuscateBuilder.setObfuscationSeed(resChiperExtension.getObfuscationSeed());
 
         if (keyStore.storeFile() != null && keyStore.storeFile().exists())
             builder.setStoreFile(keyStore.storeFile().toPath())


### PR DESCRIPTION
Added the ability to pass an obfuscation seed so that obfuscated resource names have unique hash values ​​different from the standard a0, b0, etc.